### PR TITLE
Some updates

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-  "plugins": ["transform-class-properties"]
-}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a React **H**igher **O**rder **C**omponent that you can use with your ow
 
 Note that this HOC relies on the `.classList` property, which is supported by all modern browsers, but not by no longer supported browsers like IE9 or older. If your code relies on classList in any way, you want to use a polyfill like [dom4](https://github.com/WebReflection/dom4)
 
-This HOC supports stateless components as of v5.7.0
+This HOC supports stateless components as of v5.7.0, and uses pure class notation rather than `createClass` as of v6.
 
 ## Installation
 
@@ -296,7 +296,9 @@ If you use **React 0.14**, use **v2.5 through v4.9**, as these specifically use 
 
 If you use **React 15**, you can use **v4.x, which offers both a mixin and HOC, or use v5.x, which is HOC-only**.
 
-If you use **React 15.5** (or higher), you can use **v5.11.x, which works with the externalised `create-react-class` rather than `React.createClass`.
+If you use **React 15.5**, you can use **v5.11.x**, which relies on `createClass` as supplied by `create-react-class` rather than `React.createClass`.
+
+If you use **React 16** or 15.5 in preparation of 16, use v6.x, which uses pure class notation.
 
 ### Support-wise, only the latest version will receive updates and bug fixes.
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   ],
   "homepage": "https://github.com/Pomax/react-onclickoutside",
   "authors": [
-    "Pomax <pomax@nihongoresources.com>"
+    "Pomax <pomax@nihongoresources.com>",
+    "Andarist <mateuszburzynski@gmail.com>"
   ],
   "keywords": [
     "react",
@@ -26,9 +27,11 @@
   },
   "scripts": {
     "build": "rollup -c -i src/index.js -o ./index.js",
-    "test": "npm run lint && npm run build && karma start test/karma.conf.js --single-run && npm run test:nodom",
-    "test:nodom": "mocha test/no-dom-test.js",
     "lint": "eslint src/*.js ./test",
+    "test": "run-s test:**",
+    "test:basic": "run-s lint build",
+    "test:karma": "karma start test/karma.conf.js --single-run",
+    "test:nodom": "mocha test/no-dom-test.js",
     "precommit": "npm run test"
   },
   "devDependencies": {
@@ -46,6 +49,7 @@
     "karma-spec-reporter": "0.0.26",
     "karma-webpack": "^2.0.2",
     "mocha": "^3.2.0",
+    "npm-run-all": "^4.0.2",
     "phantomjs-prebuilt": "^2.1.7",
     "react": "^15.5.x",
     "react-dom": "^15.5.x",
@@ -56,5 +60,10 @@
     "rollup-plugin-babel": "^2.7.1",
     "rollup-plugin-node-resolve": "^3.0.0",
     "webpack": "^1.15.0"
+  },
+  "babel": {
+    "plugins": [
+      "transform-class-properties"
+    ]
   }
 }

--- a/test/browser/index.html
+++ b/test/browser/index.html
@@ -34,8 +34,6 @@
 
       hr {
         margin: 2em 0;
-        border: none;
-        border-bottom: 5px dotted black;
       }
     </style>
   </head>
@@ -44,23 +42,20 @@
     <script src="../../node_modules/react-dom/dist/react-dom.js"></script>
     <script src="../../index.js"></script>
 
-
-    <button onclick="console.log('test')">test</button>
-
-    <hr>
-
+    <p>This test presents three concentric circles. Clicking inside a circle marks it as lit, clicking outside of it unmarks it.</p>
     <div id="app1"></div>
     <script src="test1.js"></script>
 
     <hr>
 
+    <p>This test presents a text, revealed with a button press. Clicking the text should preserve it, while clicking anywhere else should hide it.</p>
     <div id="app2"></div>
     <link ref="stylesheet" href="style2.css">
     <script src="test2.js"></script>
 
     <hr>
 
-    <p>Test 3 should have generated a large error and warning text in the console.</p>
+    <p>This test should have generated a large error and warning text in the console, due to intentional use of bad code.</p>
     <div id="app3"></div>
     <script src="test3.js"></script>
 

--- a/test/browser/test1.js
+++ b/test/browser/test1.js
@@ -1,35 +1,45 @@
-/**
- * Human-triggered for now, this should become a normal phantom test instead
- */
-var Nested = React.createClass({
-  getInitialState: function() {
-    return { highlight: false };
-  },
+(function test1(onClickOutside) {
 
-  handleClickOutside: function() {
-    this.setState({ highlight: false });
-  },
-
-  highlight: function() {
-    console.log(this.props.id);
-    this.setState({ highlight: true });
-  },
-
-  render: function() {
-    var className = 'concentric' + (this.state.highlight? ' highlight' : '');
-    return React.createElement('div', {
-      className: className,
-      children: this.props.children,
-      onClick: this.highlight
-    });
+  if (typeof onClickOutside === "undefined") {
+    return setTimeout(() => test1(onClickOutside), 250);
   }
-});
+
+  onClickOutside = onClickOutside.default;
+
+  /**
+   * Human-triggered for now, this should become a normal phantom test instead
+   */
+  class Nested extends React.Component {
+    constructor(props) {
+      super(props);
+      this.state = {
+        highlight: false
+      };
+    }
+
+    handleClickOutside() {
+      this.setState({ highlight: false });
+    }
+
+    highlight() {
+      console.log(this.props.id);
+      this.setState({ highlight: true });
+    }
+
+    render() {
+      var className = 'concentric' + (this.state.highlight? ' highlight' : '');
+      return React.createElement('div', {
+        className: className,
+        children: this.props.children,
+        onClick: e => this.highlight(e)
+      });
+    }
+  }
 
 
-Nested = onClickOutside(Nested); /* global onClickOutside */
+  Nested = onClickOutside(Nested);
 
-var App = React.createClass({
-  render: function() {
+  const App = function(props) {
     return React.createElement(Nested, {
       id: 1,
       stopPropagation: true,
@@ -43,7 +53,7 @@ var App = React.createClass({
         })
       })
     });
-  }
-});
+  };
 
-ReactDOM.render(React.createElement(App), document.getElementById('app1'));
+  ReactDOM.render(React.createElement(App), document.getElementById('app1'));
+}(onClickOutside));

--- a/test/browser/test2.js
+++ b/test/browser/test2.js
@@ -1,4 +1,10 @@
-(function() {
+(function test2(onClickOutside) {
+
+  if (typeof onClickOutside === "undefined") {
+    return setTimeout(() => test2(onClickOutside), 250);
+  }
+
+  onClickOutside = onClickOutside.default;
 
   class BasePopup extends React.Component {
     constructor(props) {
@@ -12,7 +18,7 @@
     }
   }
 
-  const Popup = onClickOutside(BasePopup); /* global onClickOutside */
+  const Popup = onClickOutside(BasePopup);
 
   class App extends React.Component {
     constructor(props) {
@@ -46,4 +52,4 @@
 
   ReactDOM.render(React.createElement(App), document.getElementById('app2'));
 
-}());
+}(onClickOutside));

--- a/test/browser/test3.js
+++ b/test/browser/test3.js
@@ -1,4 +1,11 @@
-(function() {
+(function test3(onClickOutside) {
+
+  if (typeof onClickOutside === "undefined") {
+    return setTimeout(() => test3(onClickOutside), 250);
+  }
+
+  onClickOutside = onClickOutside.default;
+
   class Test3Class extends React.Component {
     constructor(props) {
       super(props);
@@ -11,7 +18,7 @@
     }
   }
 
-  const Test = onClickOutside(Test3Class); /* global onClickOutside */
+  const Test = onClickOutside(Test3Class);
 
   class App extends React.Component {
     constructor(props) {
@@ -37,4 +44,4 @@
 
   ReactDOM.render(React.createElement(App), document.getElementById('app3'));
 
-}());
+}(onClickOutside));


### PR DESCRIPTION
This adds in the readme updates and the updates to the tests so that it runs off of the `index.js`, however I am seeing tests 2 and 3 in the manual browser tests not do what they're supposed to. You can verify this by running `http-server` or `live-server` or whatever convenient simple cli serve process you have installed from the base dir and visiting http://127.0.0.1:8080/test/browser/ -- while test 1 behaves as expected, test 2 hides the text "click this text" even when you click on it, which is incorrect, and test 3 no longer spawns the large warning, suggesting that dealing with `null` renders is already somehow being worked around rather than left in for follow-up fixing?